### PR TITLE
Allow passing args to phantomjs

### DIFF
--- a/tasks/phantom.js
+++ b/tasks/phantom.js
@@ -35,7 +35,7 @@ module.exports = function(grunt) {
     // Spawn PhantomJS.
     phantom = grunt.util.spawn({
       cmd: binPath,
-      args: ['--webdriver=' + port]
+      args: ['--webdriver=' + port].concat(options.args || [])
     }, function () {
       // It's a fatal error when spawned process is killed unexpectedly.
       stopped = true;


### PR DESCRIPTION
This change carries the `arg` option to the spawning of the phantomjs instance.
